### PR TITLE
feat: add SapIgnore attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,16 +127,22 @@ class SomeFunctionResultItem
 ### Exclude properties from mapping
 
 ```csharp
+class SomeFunctionParameters
+{
+    [SapIgnore]
+    public string IgnoredProperty { get; set; }
+
+    [SapName("SOME_FIELD")]
+    public string SomeField { get; set; }
+}
+
 class SomeFunctionResult
 {
     [SapIgnore]
     public string IgnoredProperty { get; set; }
 
-    [SapName("STREET")]
-    public string Street { get; set; }
-
-    [SapName("NR")]
-    public string Number { get; set; }
+    [SapName("SOME_FIELD")]
+    public string SomeField { get; set; }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ class SomeFunctionResultItem
 }
 ```
 
+### Exclude properties from mapping
+
+```csharp
+class SomeFunctionResult
+{
+    [SapIgnore]
+    public string IgnoredProperty { get; set; }
+
+    [SapName("STREET")]
+    public string Street { get; set; }
+
+    [SapName("NR")]
+    public string Number { get; set; }
+}
+```
+
 ### Ensure the SAP RFC SDK binaries are present
 
 ```csharp

--- a/src/SapNwRfc/Internal/InputMapper.cs
+++ b/src/SapNwRfc/Internal/InputMapper.cs
@@ -63,6 +63,12 @@ namespace SapNwRfc.Internal
             Expression dataHandleParameter,
             Expression inputParameter)
         {
+            // skip property from mapping
+            if (Attribute.IsDefined(propertyInfo, typeof(SapIgnoreAttribute)))
+            {
+                return null;
+            }
+
             SapNameAttribute nameAttribute = propertyInfo.GetCustomAttribute<SapNameAttribute>();
             ConstantExpression name = Expression.Constant(nameAttribute?.Name ?? propertyInfo.Name.ToUpper());
 

--- a/src/SapNwRfc/Internal/OutputMapper.cs
+++ b/src/SapNwRfc/Internal/OutputMapper.cs
@@ -57,6 +57,12 @@ namespace SapNwRfc.Internal
             Expression dataHandle,
             Expression result)
         {
+            // skip property from mapping
+            if (Attribute.IsDefined(propertyInfo, typeof(SapIgnoreAttribute)))
+            {
+                return null;
+            }
+
             SapNameAttribute nameAttribute = propertyInfo.GetCustomAttribute<SapNameAttribute>();
             ConstantExpression name = Expression.Constant(nameAttribute?.Name ?? propertyInfo.Name.ToUpper());
 

--- a/src/SapNwRfc/SapIgnoreAttribute.cs
+++ b/src/SapNwRfc/SapIgnoreAttribute.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace SapNwRfc
+{
+    /// <summary>
+    /// Attribute used to ignore a property from mapping.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SapIgnoreAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SapIgnoreAttribute"/> class.
+        /// </summary>
+        public SapIgnoreAttribute()
+        {
+        }
+    }
+}

--- a/tests/SapNwRfc.Tests/Internal/InputMapperTests.cs
+++ b/tests/SapNwRfc.Tests/Internal/InputMapperTests.cs
@@ -278,6 +278,20 @@ namespace SapNwRfc.Tests.Internal
         }
 
         [Fact]
+        public void Apply_ModelWithSapIgnoreAttribute_ShouldIgnorePropertiesWithIgnoreAttribute()
+        {
+            // Arrange
+            RfcErrorInfo errorInfo;
+            var model = new SapIgnoreAttributeModel { Value = 123 };
+
+            // Act
+            InputMapper.Apply(_interopMock.Object, DataHandle, model);
+
+            // Assert
+            _interopMock.Verify(x => x.SetInt(DataHandle, "VALUE", 123, out errorInfo), Times.Never);
+        }
+
+        [Fact]
         public void Apply_ModelWithSapNameAttribute_ShouldUseSapNameInsteadOfPropertyName()
         {
             // Arrange
@@ -334,6 +348,12 @@ namespace SapNwRfc.Tests.Internal
         private sealed class SapNameAttributeModel
         {
             [SapName("IN_VAL")]
+            public int Value { get; set; }
+        }
+
+        private sealed class SapIgnoreAttributeModel
+        {
+            [SapIgnore]
             public int Value { get; set; }
         }
 

--- a/tests/SapNwRfc.Tests/Internal/InputMapperTests.cs
+++ b/tests/SapNwRfc.Tests/Internal/InputMapperTests.cs
@@ -282,13 +282,14 @@ namespace SapNwRfc.Tests.Internal
         {
             // Arrange
             RfcErrorInfo errorInfo;
-            var model = new SapIgnoreAttributeModel { Value = 123 };
+            var model = new SapIgnoreAttributeModel { Value = 123, IgnoredProperty = 234 };
 
             // Act
             InputMapper.Apply(_interopMock.Object, DataHandle, model);
 
             // Assert
-            _interopMock.Verify(x => x.SetInt(DataHandle, "VALUE", 123, out errorInfo), Times.Never);
+            _interopMock.Verify(x => x.SetInt(DataHandle, "VALUE", 123, out errorInfo), Times.Once);
+            _interopMock.Verify(x => x.SetInt(DataHandle, "IGNOREDPROPERTY", 234, out errorInfo), Times.Never);
         }
 
         [Fact]
@@ -353,8 +354,10 @@ namespace SapNwRfc.Tests.Internal
 
         private sealed class SapIgnoreAttributeModel
         {
-            [SapIgnore]
             public int Value { get; set; }
+
+            [SapIgnore]
+            public int IgnoredProperty { get; set; }
         }
 
         private sealed class CustomNameAttribute : SapNameAttribute

--- a/tests/SapNwRfc.Tests/Internal/OutputMapperTests.cs
+++ b/tests/SapNwRfc.Tests/Internal/OutputMapperTests.cs
@@ -531,6 +531,30 @@ namespace SapNwRfc.Tests.Internal
         }
 
         [Fact]
+        public void Extract_PropertyWithIgnoreAttribute_ShouldBeIgnored()
+        {
+            // Arrange
+            int value = 123;
+            RfcErrorInfo errorInfo;
+            _interopMock.Setup(x => x.GetInt(DataHandle, "VALUE", out value, out errorInfo));
+
+            // Act
+            IgnoreAttributeModel result = OutputMapper.Extract<IgnoreAttributeModel>(_interopMock.Object, DataHandle);
+
+            // Assert
+            _interopMock.Verify(x => x.GetInt(DataHandle, "VALUE", out value, out errorInfo), Times.Never);
+
+            result.Should().NotBeNull();
+            result.Value.Should().Be(0);
+        }
+
+        private sealed class IgnoreAttributeModel
+        {
+            [SapIgnore]
+            public int Value { get; set; }
+        }
+
+        [Fact]
         public void Extract_UnknownTypeThatCannotBeExtracted_ShouldThrowException()
         {
             // Arrange & Act


### PR DESCRIPTION
Currently, all properties in a model are mapped and sent to SAP. This could lead to errors if the model includes properties which do not exist in the SAP RFC:
`SAP RFC Error: RFC_INVALID_PARAMETER with message: field '...' not found`

This PR adds a second attribute which marks properties to be excluded from the mapping.