### PR TITLE
feat: implement OnInitialize method

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,24 @@ class SomeFunctionResultItem
 }
 ```
 
+### Define models with a OnInitialize method. Combined with the SapIgnoreAttribute, calculated properties can be created
+
+```csharp
+class SomeFunctionResult
+{
+    public string FirstName { get; set; }
+
+    public string LastName { get; set; }
+
+    [SapIgnore]
+    public string FullName { get; set; }
+
+    public void OnInitialize() {
+        FullName = string.Concat(FirstName, LastName);
+    }
+}
+```
+
 ### Ensure the SAP RFC SDK binaries are present
 
 ```csharp

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ class SomeFunctionResultItem
 ### Define models with a OnInitialize method. Combined with the SapIgnoreAttribute, calculated properties can be created
 
 ```csharp
-class SomeFunctionResult
+class SomeFunctionResult : ISapOnInitialize
 {
     public string FirstName { get; set; }
 

--- a/src/SapNwRfc/ISapOnInitialize.cs
+++ b/src/SapNwRfc/ISapOnInitialize.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SapNwRfc
+{
+    /// <summary>
+    /// Base class for OnInitialize Method.
+    /// </summary>
+    public interface ISapOnInitialize
+    {
+        /// <summary>
+        /// Method called after class is instantiated and values from SAP assigned to properties.
+        /// </summary>
+        void OnInitialize();
+    }
+}

--- a/src/SapNwRfc/Internal/Fields/StructureField.cs
+++ b/src/SapNwRfc/Internal/Fields/StructureField.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using SapNwRfc.Internal.Interop;
 
 namespace SapNwRfc.Internal.Fields
@@ -36,6 +37,13 @@ namespace SapNwRfc.Internal.Fields
             resultCode.ThrowOnError(errorInfo);
 
             T structValue = OutputMapper.Extract<T>(interop, structHandle);
+
+            var onInitialize = structValue.GetType()?.GetMethod("OnInitialize", BindingFlags.Instance);
+
+            if (onInitialize != null)
+            {
+                onInitialize.Invoke(structValue, null);
+            }
 
             return new StructureField<T>(name, structValue);
         }

--- a/tests/SapNwRfc.Tests/Internal/OutputMapperTests.cs
+++ b/tests/SapNwRfc.Tests/Internal/OutputMapperTests.cs
@@ -540,17 +540,16 @@ namespace SapNwRfc.Tests.Internal
 
             // Assert
             result.Should().NotBeNull();
-            result.OnInitializeCalled.Should().BeTrue();
+            result.OnInitializeCalled.Should().Be(1);
         }
 
         private sealed class OnIntializeAttributeModel
         {
-            [SapIgnore]
-            public bool OnInitializeCalled { get; set; } = false;
+            public int OnInitializeCalled { get; set; } = 0;
 
             public void OnInitialize()
             {
-                OnInitializeCalled = true;
+                OnInitializeCalled = 1;
             }
         }
 
@@ -564,20 +563,19 @@ namespace SapNwRfc.Tests.Internal
 
             // Assert
             result.Should().NotBeNull();
-            result.OnInitializeCalled.Should().BeTrue();
-            result.NestedObject.OnInitializeCalled.Should().BeTrue();
+            result.OnInitializeCalled.Should().Be(1);
+            result.NestedObject.OnInitializeCalled.Should().Be(1);
         }
 
         private sealed class NestedOnIntializeAttributeModel
         {
             public OnIntializeAttributeModel NestedObject { get; set; }
 
-            [SapIgnore]
-            public bool OnInitializeCalled { get; set; } = false;
+            public int OnInitializeCalled { get; set; } = 0;
 
             public void OnInitialize()
             {
-                OnInitializeCalled = true;
+                OnInitializeCalled = 1;
             }
         }
 

--- a/tests/SapNwRfc.Tests/Internal/OutputMapperTests.cs
+++ b/tests/SapNwRfc.Tests/Internal/OutputMapperTests.cs
@@ -543,7 +543,7 @@ namespace SapNwRfc.Tests.Internal
             result.OnInitializeCalled.Should().Be(1);
         }
 
-        private sealed class OnIntializeAttributeModel
+        private sealed class OnIntializeAttributeModel : ISapOnInitialize
         {
             public int OnInitializeCalled { get; set; } = 0;
 
@@ -567,7 +567,7 @@ namespace SapNwRfc.Tests.Internal
             result.NestedObject.OnInitializeCalled.Should().Be(1);
         }
 
-        private sealed class NestedOnIntializeAttributeModel
+        private sealed class NestedOnIntializeAttributeModel : ISapOnInitialize
         {
             public OnIntializeAttributeModel NestedObject { get; set; }
 

--- a/tests/SapNwRfc.Tests/Internal/OutputMapperTests.cs
+++ b/tests/SapNwRfc.Tests/Internal/OutputMapperTests.cs
@@ -531,6 +531,57 @@ namespace SapNwRfc.Tests.Internal
         }
 
         [Fact]
+        public void Extract_ClassWithOnInitializeFunction_ShouldCallOnInitialize()
+        {
+            // Arrange
+
+            // Act
+            OnIntializeAttributeModel result = OutputMapper.Extract<OnIntializeAttributeModel>(_interopMock.Object, DataHandle);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.OnInitializeCalled.Should().BeTrue();
+        }
+
+        private sealed class OnIntializeAttributeModel
+        {
+            [SapIgnore]
+            public bool OnInitializeCalled { get; set; } = false;
+
+            public void OnInitialize()
+            {
+                OnInitializeCalled = true;
+            }
+        }
+
+        [Fact]
+        public void Extract_ClassWithNestedOnInitializeFunction_ShouldCallAllOnInitialize()
+        {
+            // Arrange
+
+            // Act
+            NestedOnIntializeAttributeModel result = OutputMapper.Extract<NestedOnIntializeAttributeModel>(_interopMock.Object, DataHandle);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.OnInitializeCalled.Should().BeTrue();
+            result.NestedObject.OnInitializeCalled.Should().BeTrue();
+        }
+
+        private sealed class NestedOnIntializeAttributeModel
+        {
+            public OnIntializeAttributeModel NestedObject { get; set; }
+
+            [SapIgnore]
+            public bool OnInitializeCalled { get; set; } = false;
+
+            public void OnInitialize()
+            {
+                OnInitializeCalled = true;
+            }
+        }
+
+        [Fact]
         public void Extract_UnknownTypeThatCannotBeExtracted_ShouldThrowException()
         {
             // Arrange & Act


### PR DESCRIPTION
An `OnInitialize` method can be defined on the model class that will be called after the instance is created and values from SAP are assigned. Combined with the `SapIgnoreAttribute` this enables calculated fields to be created on the model without needing to loop the results after .Invoke()