### PR TITLE
Only create a new array when advertised row count is below actual row…

### DIFF
--- a/src/SapNwRfc/Internal/Fields/TableField.cs
+++ b/src/SapNwRfc/Internal/Fields/TableField.cs
@@ -78,7 +78,12 @@ namespace SapNwRfc.Internal.Fields
                         errorInfo: out errorInfo);
 
                     if (resultCode == RfcResultCode.RFC_TABLE_MOVE_EOF)
-                        return new TableField<T>(name, rows.Take(i + 1).ToArray());
+                    {
+                        if (i + 1 < rowCount)
+                            Array.Resize(ref rows, i + 1);
+
+                        break;
+                    }
 
                     resultCode.ThrowOnError(errorInfo);
                 }

--- a/src/SapNwRfc/Internal/Fields/TableField.cs
+++ b/src/SapNwRfc/Internal/Fields/TableField.cs
@@ -79,9 +79,7 @@ namespace SapNwRfc.Internal.Fields
 
                     if (resultCode == RfcResultCode.RFC_TABLE_MOVE_EOF)
                     {
-                        if (i + 1 < rowCount)
-                            Array.Resize(ref rows, i + 1);
-
+                        Array.Resize(ref rows, i + 1);
                         break;
                     }
 


### PR DESCRIPTION
… count

Before a new array was always created if `rowCount > 0`.

~~The `if` check isn't necessary before `Array.Resize` since the length is there checked too 
https://github.com/dotnet/runtime/blob/8b6f404bd5de08f322e5385458886b64c01ce258/src/libraries/System.Private.CoreLib/src/System/Array.cs#L52~~
I have removed the `if` check so codecov is happy.