### PR TITLE
Avoid string allocations in DateField / DecimalField / TimeField when…

### DIFF
--- a/src/SapNwRfc/Internal/Fields/DateField.cs
+++ b/src/SapNwRfc/Internal/Fields/DateField.cs
@@ -19,12 +19,7 @@ namespace SapNwRfc.Internal.Fields
 
         public override void Apply(RfcInterop interop, IntPtr dataHandle)
         {
-#if NETSTANDARD2_0
             char[] buffer = (Value?.ToString(RfcDateFormat, CultureInfo.InvariantCulture) ?? ZeroRfcDateString).ToCharArray();
-#else
-            char[] buffer = ZeroRfcDateString.ToCharArray();
-            Value?.TryFormat(buffer, out var _, RfcDateFormat, CultureInfo.InvariantCulture);
-#endif
 
             RfcResultCode resultCode = interop.SetDate(
                 dataHandle: dataHandle,
@@ -47,17 +42,10 @@ namespace SapNwRfc.Internal.Fields
 
             resultCode.ThrowOnError(errorInfo);
 
-#if NETSTANDARD2_0
             string dateString = new string(buffer);
 
             if (dateString == EmptyRfcDateString || dateString == ZeroRfcDateString)
                 return new DateField(name, null);
-#else
-            Span<char> dateString = buffer.AsSpan();
-
-            if (dateString.SequenceEqual(EmptyRfcDateString) || dateString.SequenceEqual(ZeroRfcDateString))
-                return new DateField(name, null);
-#endif
 
             if (!DateTime.TryParseExact(dateString, RfcDateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime date))
                 return new DateField(name, null);

--- a/src/SapNwRfc/Internal/Fields/DateField.cs
+++ b/src/SapNwRfc/Internal/Fields/DateField.cs
@@ -8,9 +8,9 @@ namespace SapNwRfc.Internal.Fields
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Reflection use")]
     internal sealed class DateField : Field<DateTime?>
     {
+        private const string RfcDateFormat = "yyyyMMdd";
         private static readonly string ZeroRfcDateString = new string('0', 8);
         private static readonly string EmptyRfcDateString = new string(' ', 8);
-        private static readonly string RfcDateFormat = "yyyyMMdd";
 
         public DateField(string name, DateTime? value)
             : base(name, value)
@@ -19,12 +19,12 @@ namespace SapNwRfc.Internal.Fields
 
         public override void Apply(RfcInterop interop, IntPtr dataHandle)
         {
-            char[] buffer = (Value?.ToString(RfcDateFormat, CultureInfo.InvariantCulture) ?? ZeroRfcDateString).ToCharArray();
+            string stringValue = Value?.ToString(RfcDateFormat, CultureInfo.InvariantCulture) ?? ZeroRfcDateString;
 
             RfcResultCode resultCode = interop.SetDate(
                 dataHandle: dataHandle,
                 name: Name,
-                date: buffer,
+                date: stringValue.ToCharArray(),
                 errorInfo: out RfcErrorInfo errorInfo);
 
             resultCode.ThrowOnError(errorInfo);

--- a/src/SapNwRfc/Internal/Fields/DecimalField.cs
+++ b/src/SapNwRfc/Internal/Fields/DecimalField.cs
@@ -54,7 +54,11 @@ namespace SapNwRfc.Internal.Fields
 
             resultCode.ThrowOnError(errorInfo);
 
+#if NETSTANDARD2_0
             var decimalValue = decimal.Parse(new string(buffer, 0, (int)stringLength), CultureInfo.InvariantCulture);
+#else
+            var decimalValue = decimal.Parse(buffer.AsSpan(), provider: CultureInfo.InvariantCulture);
+#endif
 
             return new DecimalField(name, decimalValue);
         }

--- a/src/SapNwRfc/Internal/Fields/DecimalField.cs
+++ b/src/SapNwRfc/Internal/Fields/DecimalField.cs
@@ -54,11 +54,7 @@ namespace SapNwRfc.Internal.Fields
 
             resultCode.ThrowOnError(errorInfo);
 
-#if NETSTANDARD2_0
             var decimalValue = decimal.Parse(new string(buffer, 0, (int)stringLength), CultureInfo.InvariantCulture);
-#else
-            var decimalValue = decimal.Parse(buffer.AsSpan(), provider: CultureInfo.InvariantCulture);
-#endif
 
             return new DecimalField(name, decimalValue);
         }

--- a/src/SapNwRfc/Internal/Fields/TimeField.cs
+++ b/src/SapNwRfc/Internal/Fields/TimeField.cs
@@ -8,9 +8,9 @@ namespace SapNwRfc.Internal.Fields
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Reflection use")]
     internal sealed class TimeField : Field<TimeSpan?>
     {
+        private const string RfcTimeFormat = "hhmmss";
         private static readonly string ZeroRfcTimeString = new string('0', 6);
         private static readonly string EmptyRfcTimeString = new string(' ', 6);
-        private static readonly string RfcTimeFormat = "hhmmss";
 
         public TimeField(string name, TimeSpan? value)
             : base(name, value)
@@ -19,12 +19,12 @@ namespace SapNwRfc.Internal.Fields
 
         public override void Apply(RfcInterop interop, IntPtr dataHandle)
         {
-            char[] buffer = (Value?.ToString(RfcTimeFormat, CultureInfo.InvariantCulture) ?? ZeroRfcTimeString).ToCharArray();
+            string stringValue = Value?.ToString(RfcTimeFormat, CultureInfo.InvariantCulture) ?? ZeroRfcTimeString;
 
             RfcResultCode resultCode = interop.SetTime(
                 dataHandle: dataHandle,
                 name: Name,
-                time: buffer,
+                time: stringValue.ToCharArray(),
                 out RfcErrorInfo errorInfo);
 
             resultCode.ThrowOnError(errorInfo);
@@ -42,7 +42,7 @@ namespace SapNwRfc.Internal.Fields
 
             resultCode.ThrowOnError(errorInfo);
 
-            string timeString = new string(buffer);
+            var timeString = new string(buffer);
 
             if (timeString == EmptyRfcTimeString || timeString == ZeroRfcTimeString)
                 return new TimeField(name, null);

--- a/src/SapNwRfc/Internal/Fields/TimeField.cs
+++ b/src/SapNwRfc/Internal/Fields/TimeField.cs
@@ -19,12 +19,7 @@ namespace SapNwRfc.Internal.Fields
 
         public override void Apply(RfcInterop interop, IntPtr dataHandle)
         {
-#if NETSTANDARD2_0
             char[] buffer = (Value?.ToString(RfcTimeFormat, CultureInfo.InvariantCulture) ?? ZeroRfcTimeString).ToCharArray();
-#else
-            char[] buffer = ZeroRfcTimeString.ToCharArray();
-            Value?.TryFormat(buffer, out var _, RfcTimeFormat, CultureInfo.InvariantCulture);
-#endif
 
             RfcResultCode resultCode = interop.SetTime(
                 dataHandle: dataHandle,
@@ -47,17 +42,10 @@ namespace SapNwRfc.Internal.Fields
 
             resultCode.ThrowOnError(errorInfo);
 
-#if NETSTANDARD2_0
             string timeString = new string(buffer);
 
             if (timeString == EmptyRfcTimeString || timeString == ZeroRfcTimeString)
                 return new TimeField(name, null);
-#else
-            Span<char> timeString = buffer.AsSpan();
-
-            if (timeString.SequenceEqual(EmptyRfcTimeString) || timeString.SequenceEqual(ZeroRfcTimeString))
-                return new TimeField(name, null);
-#endif
 
             if (!TimeSpan.TryParseExact(timeString, RfcTimeFormat, CultureInfo.InvariantCulture, out TimeSpan time))
                 return new TimeField(name, null);


### PR DESCRIPTION
… targeting netstandard2.1

Also removes `Regex` parsing. Was there a specific reason to use it instead of date/time format strings?

---

There is a new `LogFilePrefix` for `vstest` so the `trx` files for the different `TargetFrameworks` don't override each other. 
https://github.com/microsoft/vstest-docs/pull/204/files?short_path=3562af9#diff-3562af9d9cfa496e16a73dfbcf906d7330a8d5a16a53c17df4e7c4b0f18901ac
https://github.com/microsoft/vstest/pull/2140
https://github.com/microsoft/vstest/issues/1603

