### PR TITLE
Fix RfcFunctionDescriptionCallback signature

### DIFF
--- a/src/SapNwRfc/Internal/Interop/RfcInterop.cs
+++ b/src/SapNwRfc/Internal/Interop/RfcInterop.cs
@@ -254,7 +254,7 @@ namespace SapNwRfc.Internal.Interop
         public delegate RfcResultCode RfcServerFunction(IntPtr connectionHandle, IntPtr functionHandle, out RfcErrorInfo errorInfo);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public delegate RfcResultCode RfcFunctionDescriptionCallback(string functionName, ref RfcAttributes attributes, out IntPtr funcDescHandle);
+        public delegate RfcResultCode RfcFunctionDescriptionCallback(string functionName, RfcAttributes attributes, ref IntPtr funcDescHandle);
 
         [DllImport(SapNwRfcDllName)]
         private static extern RfcResultCode RfcInstallGenericServerFunction(RfcServerFunction serverFunction, RfcFunctionDescriptionCallback funcDescPointer, out RfcErrorInfo errorInfo);

--- a/src/SapNwRfc/SapServer.cs
+++ b/src/SapNwRfc/SapServer.cs
@@ -109,7 +109,7 @@ namespace SapNwRfc
             RfcResultCode resultCode = interop.InstallGenericServerFunction(
                 serverFunction: (IntPtr connectionHandle, IntPtr functionHandle, out RfcErrorInfo errorInfo)
                                     => HandleGenericFunction(interop, action, connectionHandle, functionHandle, out errorInfo),
-                funcDescPointer: (string functionName, ref RfcAttributes attributes, out IntPtr funcDescHandle)
+                funcDescPointer: (string functionName, RfcAttributes attributes, ref IntPtr funcDescHandle)
                                     => HandleGenericMetadata(interop, parameters, functionName, out funcDescHandle),
                 out RfcErrorInfo installFunctionErrorInfo);
 


### PR DESCRIPTION
I used the wrong signature for `RfcFunctionDescriptionCallback` which apparently worked on windows but not on linux / macos.

@tom-j-irvine it would be great if you could confirm that this fixes your issue.

Fixes https://github.com/huysentruitw/SapNwRfc/issues/49