### PR TITLE
Add CreateFunction / GetTypeMetadata / GetFunctionMetadata to ISapServerConnection

### DIFF
--- a/src/SapNwRfc/ISapConnection.cs
+++ b/src/SapNwRfc/ISapConnection.cs
@@ -50,10 +50,10 @@ namespace SapNwRfc
         ISapFunctionMetadata GetFunctionMetadata(string functionName);
 
         /// <summary>
-        /// Creates a <see cref="SapFunction"/> object for invoking the remote function.
+        /// Creates a <see cref="ISapFunction"/> object for invoking the remote function.
         /// </summary>
         /// <param name="name">The name of the remote function.</param>
-        /// <returns>The <see cref="SapFunction"/> object.</returns>
+        /// <returns>The <see cref="ISapFunction"/> object.</returns>
         ISapFunction CreateFunction(string name);
     }
 }

--- a/src/SapNwRfc/ISapServerConnection.cs
+++ b/src/SapNwRfc/ISapServerConnection.cs
@@ -10,5 +10,26 @@ namespace SapNwRfc
         /// </summary>
         /// <returns>The connection attributes.</returns>
         SapAttributes GetAttributes();
+
+        /// <summary>
+        /// Gets the metadata for the specified type name.
+        /// </summary>
+        /// <param name="typeName">The type name.</param>
+        /// <returns>The metadata for the type name.</returns>
+        ISapTypeMetadata GetTypeMetadata(string typeName);
+
+        /// <summary>
+        /// Gets the metadata for the specified function name.
+        /// </summary>
+        /// <param name="functionName">The function name.</param>
+        /// <returns>The matadata for the function name.</returns>
+        ISapFunctionMetadata GetFunctionMetadata(string functionName);
+
+        /// <summary>
+        /// Creates a <see cref="ISapFunction"/> object for invoking the remote function.
+        /// </summary>
+        /// <param name="name">The name of the remote function.</param>
+        /// <returns>The <see cref="ISapFunction"/> object.</returns>
+        ISapFunction CreateFunction(string name);
     }
 }

--- a/src/SapNwRfc/SapServerConnection.cs
+++ b/src/SapNwRfc/SapServerConnection.cs
@@ -29,5 +29,47 @@ namespace SapNwRfc
 
             return new SapAttributes(attributes);
         }
+
+        /// <inheritdoc cref="ISapServerConnection"/>
+        public ISapTypeMetadata GetTypeMetadata(string typeName)
+        {
+            IntPtr typeDescriptionHandle = _interop.GetTypeDesc(
+               rfcHandle: _rfcConnectionHandle,
+               typeName: typeName,
+               errorInfo: out RfcErrorInfo errorInfo);
+
+            errorInfo.ThrowOnError();
+
+            return new SapTypeMetadata(_interop, typeDescriptionHandle);
+        }
+
+        /// <inheritdoc cref="ISapServerConnection"/>
+        public ISapFunctionMetadata GetFunctionMetadata(string functionName)
+        {
+            IntPtr functionDescriptionHandle = _interop.GetFunctionDesc(
+               rfcHandle: _rfcConnectionHandle,
+               funcName: functionName,
+               errorInfo: out RfcErrorInfo errorInfo);
+
+            errorInfo.ThrowOnError();
+
+            return new SapFunctionMetadata(_interop, functionDescriptionHandle);
+        }
+
+        /// <inheritdoc cref="ISapServerConnection"/>
+        public ISapFunction CreateFunction(string name)
+        {
+            IntPtr functionDescriptionHandle = _interop.GetFunctionDesc(
+                rfcHandle: _rfcConnectionHandle,
+                funcName: name,
+                errorInfo: out RfcErrorInfo errorInfo);
+
+            errorInfo.ThrowOnError();
+
+            return SapFunction.CreateFromDescriptionHandle(
+                interop: _interop,
+                rfcConnectionHandle: _rfcConnectionHandle,
+                functionDescriptionHandle: functionDescriptionHandle);
+        }
     }
 }


### PR DESCRIPTION
The `connectionHandle` which gets passed to `RfcServerFunction` can be used to call back into SAP to get metadata and call functions.
I also tried to add `Ping` but it always returned `RFC_INVALID_HANDLE`.

```c#
SapServer.InstallGenericServerFunctionHandler(clientParameters, (connection, function) =>
{
    // call back into SAP to get metadata and call functions
    var functionMetadata = connection.GetFunctionMetadata("BAPI_SOME_FUNCTION_NAME");
    var typeMetadata = connection.GetTypeMetadata("MY_STRUCT");
    using (var fn = connection.CreateFunction("BAPI_SOME_FUNCTION_NAME"))
    {
        fn.Invoke();
    }

    // handle the actual server function call
    switch (function.GetName())
    {
    case "BAPI_SOME_FUNCTION_NAME":
        function.SetResult(new { RESULT = "X" });
        break;
    }
});
```