### PR TITLE
Support variable length bytes

### DIFF
--- a/src/SapNwRfc/Internal/Fields/BytesField.cs
+++ b/src/SapNwRfc/Internal/Fields/BytesField.cs
@@ -27,20 +27,57 @@ namespace SapNwRfc.Internal.Fields
             resultCode.ThrowOnError(errorInfo);
         }
 
-        public static BytesField Extract(RfcInterop interop, IntPtr dataHandle, string name, int bufferLength)
+        public static BytesField Extract(RfcInterop interop, IntPtr dataHandle, string name, int? bufferLength)
         {
-            var buffer = new byte[bufferLength];
+            if (bufferLength == null)
+            {
+                RfcResultCode resultCode = interop.GetXString(
+                    dataHandle: dataHandle,
+                    name: name,
+                    bytesBuffer: Array.Empty<byte>(),
+                    bufferLength: 0,
+                    xstringLength: out uint xstringLength,
+                    errorInfo: out RfcErrorInfo errorInfo);
 
-            RfcResultCode resultCode = interop.GetBytes(
-                dataHandle: dataHandle,
-                name: name,
-                bytesBuffer: buffer,
-                bufferLength: (uint)buffer.Length,
-                errorInfo: out RfcErrorInfo errorInfo);
+                if (xstringLength == 0)
+                {
+                    return new BytesField(name, Array.Empty<byte>());
+                }
 
-            resultCode.ThrowOnError(errorInfo);
+                if (resultCode != RfcResultCode.RFC_BUFFER_TOO_SMALL)
+                {
+                    resultCode.ThrowOnError(errorInfo);
+                    return new BytesField(name, Array.Empty<byte>());
+                }
 
-            return new BytesField(name, buffer);
+                var buffer = new byte[xstringLength];
+                resultCode = interop.GetXString(
+                    dataHandle: dataHandle,
+                    name: name,
+                    bytesBuffer: buffer,
+                    bufferLength: (uint)buffer.Length,
+                    xstringLength: out _,
+                    errorInfo: out errorInfo);
+
+                resultCode.ThrowOnError(errorInfo);
+
+                return new BytesField(name, buffer);
+            }
+            else
+            {
+                var buffer = new byte[bufferLength.Value];
+
+                RfcResultCode resultCode = interop.GetBytes(
+                    dataHandle: dataHandle,
+                    name: name,
+                    bytesBuffer: buffer,
+                    bufferLength: (uint)buffer.Length,
+                    errorInfo: out RfcErrorInfo errorInfo);
+
+                resultCode.ThrowOnError(errorInfo);
+
+                return new BytesField(name, buffer);
+            }
         }
 
         [ExcludeFromCodeCoverage]

--- a/src/SapNwRfc/Internal/Interop/RfcInterop.cs
+++ b/src/SapNwRfc/Internal/Interop/RfcInterop.cs
@@ -262,6 +262,12 @@ namespace SapNwRfc.Internal.Interop
             => RfcGetBytes(dataHandle, name, bytesBuffer, bufferLength, out errorInfo);
 
         [DllImport(SapNwRfcDllName, CharSet = CharSet.Unicode)]
+        private static extern RfcResultCode RfcGetXString(IntPtr dataHandle, string name, byte[] bytesBuffer, uint bufferLength, out uint xstringLength, out RfcErrorInfo errorInfo);
+
+        public virtual RfcResultCode GetXString(IntPtr dataHandle, string name, byte[] bytesBuffer, uint bufferLength, out uint xstringLength, out RfcErrorInfo errorInfo)
+            => RfcGetXString(dataHandle, name, bytesBuffer, bufferLength, out xstringLength, out errorInfo);
+
+        [DllImport(SapNwRfcDllName, CharSet = CharSet.Unicode)]
         private static extern RfcResultCode RfcSetBytes(IntPtr dataHandle, string name, byte[] value, uint valueLength, out RfcErrorInfo errorInfo);
 
         public virtual RfcResultCode SetBytes(IntPtr dataHandle, string name, byte[] value, uint valueLength, out RfcErrorInfo errorInfo)

--- a/src/SapNwRfc/Internal/OutputMapper.cs
+++ b/src/SapNwRfc/Internal/OutputMapper.cs
@@ -98,7 +98,7 @@ namespace SapNwRfc.Internal
                 extractMethod = GetMethodInfo(() => BytesField.Extract(default, default, default, default));
 
                 SapBufferLengthAttribute bufferLengthAttribute = propertyInfo.GetCustomAttribute<SapBufferLengthAttribute>();
-                arguments.Add(Expression.Constant(bufferLengthAttribute?.BufferLength ?? 0));
+                arguments.Add(Expression.Constant(bufferLengthAttribute?.BufferLength, typeof(int?)));
             }
             else if (propertyInfo.PropertyType == typeof(char[]))
             {


### PR DESCRIPTION
`RfcGetXString` can be used to read variable length bytes similar to `RfcGetString`.

According to the docs `RfcGetXString` supports these types:
```
     * - RFCTYPE_BYTE
     * - RFCTYPE_XSTRING
     * - RFCTYPE_CHAR
     * - RFCTYPE_NUM
     * - RFCTYPE_DATE
     * - RFCTYPE_TIME
     * - RFCTYPE_INTx
     * - RFCTYPE_FLOAT
     * - RFCTYPE_BCD
     * - RFCTYPE_DECFxx
```
Which are exactly the same as in `RfcGetBytes`:
```
     * - RFCTYPE_BYTE
     * - RFCTYPE_XSTRING
     * - RFCTYPE_CHAR
     * - RFCTYPE_NUM
     * - RFCTYPE_DATE
     * - RFCTYPE_TIME
     * - RFCTYPE_INTx
     * - RFCTYPE_FLOAT
     * - RFCTYPE_BCD
     * - RFCTYPE_DECFxx
```