### PR TITLE
Dynamic Function Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ var result = someFunction.Invoke<SomeFunctionResult>(new SomeFunctionParameters
 // Do something with result.Abc
 ```
 
+### Call function with dynamic input and output parameters
+
+```csharp
+using var someFunction = connection.CreateFunction("BAPI_SOME_FUNCTION_NAME");
+var result = someFunction.Invoke<dynamic>(new
+{
+    SOME_FIELD = "Some value",
+});
+
+string abc = result.RES_ABC;
+```
+
 ### Define models with a nested structure
 
 ```csharp

--- a/src/SapNwRfc/Internal/Dynamic/DynamicRfc.cs
+++ b/src/SapNwRfc/Internal/Dynamic/DynamicRfc.cs
@@ -1,0 +1,97 @@
+using System;
+using SapNwRfc.Internal.Fields;
+using SapNwRfc.Internal.Interop;
+
+namespace SapNwRfc.Internal.Dynamic
+{
+    internal static class DynamicRfc
+    {
+        internal static bool TryGetRfcValue(RfcInterop interop, IntPtr dataHandle, string name, SapRfcType type, Func<ISapTypeMetadata> typeMetadata, Type returnType, out object result)
+        {
+            result = GetRfcValue(interop, dataHandle, name, type, typeMetadata);
+
+            if (returnType == typeof(object))
+            {
+                return true;
+            }
+
+            try
+            {
+                result = Convert.ChangeType(result, returnType);
+                return true;
+            }
+            catch { }
+
+            result = null;
+            return false;
+        }
+
+        private static object GetRfcValue(RfcInterop interop, IntPtr dataHandle, string name, SapRfcType type, Func<ISapTypeMetadata> typeMetadata)
+        {
+            switch (type)
+            {
+            case SapRfcType.RFCTYPE_CHAR:
+            case SapRfcType.RFCTYPE_NUM:
+            case SapRfcType.RFCTYPE_BCD:
+            case SapRfcType.RFCTYPE_STRING:
+                return StringField.Extract(interop, dataHandle, name).Value;
+
+            case SapRfcType.RFCTYPE_INT:
+            case SapRfcType.RFCTYPE_INT1:
+            case SapRfcType.RFCTYPE_INT2:
+                return IntField.Extract(interop, dataHandle, name).Value;
+
+            case SapRfcType.RFCTYPE_INT8:
+                return LongField.Extract(interop, dataHandle, name).Value;
+
+            case SapRfcType.RFCTYPE_FLOAT:
+                return DoubleField.Extract(interop, dataHandle, name).Value;
+
+            case SapRfcType.RFCTYPE_DECF16:
+            case SapRfcType.RFCTYPE_DECF34:
+                return DecimalField.Extract(interop, dataHandle, name).Value;
+
+            case SapRfcType.RFCTYPE_DATE:
+                return DateField.Extract(interop, dataHandle, name).Value;
+
+            case SapRfcType.RFCTYPE_TIME:
+                return TimeField.Extract(interop, dataHandle, name).Value;
+
+            case SapRfcType.RFCTYPE_BYTE:
+            case SapRfcType.RFCTYPE_XSTRING:
+                return BytesField.Extract(interop, dataHandle, name, bufferLength: 0).Value;
+
+            case SapRfcType.RFCTYPE_TABLE:
+                {
+                    RfcResultCode resultCode = interop.GetTable(
+                        dataHandle: dataHandle,
+                        name: name,
+                        tableHandle: out IntPtr tableHandle,
+                        errorInfo: out RfcErrorInfo errorInfo);
+
+                    resultCode.ThrowOnError(errorInfo);
+
+                    return new DynamicRfcTable(interop, tableHandle, typeMetadata());
+                }
+
+            case SapRfcType.RFCTYPE_STRUCTURE:
+                {
+                    RfcResultCode resultCode = interop.GetStructure(
+                        dataHandle: dataHandle,
+                        name: name,
+                        structHandle: out IntPtr structHandle,
+                        errorInfo: out RfcErrorInfo errorInfo);
+
+                    resultCode.ThrowOnError(errorInfo);
+
+                    return new DynamicRfcStructure(interop, structHandle, typeMetadata());
+                }
+
+            case SapRfcType.RFCTYPE_NULL:
+                return null;
+            }
+
+            throw new NotSupportedException($"Parameter type {type} is not supported");
+        }
+    }
+}

--- a/src/SapNwRfc/Internal/Dynamic/DynamicRfcFunction.cs
+++ b/src/SapNwRfc/Internal/Dynamic/DynamicRfcFunction.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using SapNwRfc.Internal.Interop;
+
+namespace SapNwRfc.Internal.Dynamic
+{
+    internal sealed class DynamicRfcFunction : DynamicObject, IReadOnlyDictionary<string, object>
+    {
+        private readonly RfcInterop _interop;
+        private readonly IntPtr _functionHandle;
+        private readonly ISapFunctionMetadata _functionMetadata;
+
+        internal DynamicRfcFunction(RfcInterop interop, IntPtr functionHandle, ISapFunctionMetadata functionMetadata)
+        {
+            _interop = interop;
+            _functionHandle = functionHandle;
+            _functionMetadata = functionMetadata;
+        }
+
+        private bool TryGetByName(string name, Type returnType, out object result)
+        {
+            if (_functionMetadata.Parameters.TryGetValue(name, out ISapParameterMetadata parameter))
+            {
+                if (DynamicRfc.TryGetRfcValue(_interop, _functionHandle, parameter.Name, parameter.Type, parameter.GetTypeMetadata, returnType, out result))
+                {
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        private bool TryGetByIndex(int index, Type returnType, out object result)
+        {
+            if (index >= 0 && index < _functionMetadata.Parameters.Count)
+            {
+                ISapParameterMetadata parameter = _functionMetadata.Parameters[index];
+
+                if (DynamicRfc.TryGetRfcValue(_interop, _functionHandle, parameter.Name, parameter.Type, parameter.GetTypeMetadata, returnType, out result))
+                {
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        public override IEnumerable<string> GetDynamicMemberNames()
+        {
+            return Keys;
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            return TryGetByName(binder.Name, binder.ReturnType, out result);
+        }
+
+        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+        {
+            if (indexes.Length != 1)
+                throw new ArgumentOutOfRangeException(nameof(indexes));
+
+            var index = indexes[0];
+
+            if (index is string name)
+                return TryGetByName(name, binder.ReturnType, out result);
+
+            if (index is int i)
+                return TryGetByIndex(i, binder.ReturnType, out result);
+
+            if (index is uint u)
+                return TryGetByIndex((int)u, binder.ReturnType, out result);
+
+            throw new ArgumentException(nameof(indexes));
+        }
+
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+        {
+            if (binder.Name == "GetMetadata" && binder.CallInfo.ArgumentCount == 0)
+            {
+                result = _functionMetadata;
+                return true;
+            }
+
+            return base.TryInvokeMember(binder, args, out result);
+        }
+
+        public IEnumerable<string> Keys
+        {
+            get
+            {
+                foreach (var parameter in _functionMetadata.Parameters)
+                {
+                    yield return parameter.Name;
+                }
+            }
+        }
+
+        public IEnumerable<object> Values
+        {
+            get
+            {
+                foreach (var parameter in _functionMetadata.Parameters)
+                {
+                    if (TryGetByName(parameter.Name, typeof(object), out object result))
+                    {
+                        yield return result;
+                    }
+                }
+            }
+        }
+
+        public int Count => _functionMetadata.Parameters.Count;
+
+        public object this[string key]
+        {
+            get
+            {
+                if (TryGetByName(key, typeof(object), out var result))
+                {
+                    return result;
+                }
+
+                throw new KeyNotFoundException();
+            }
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _functionMetadata.Parameters.TryGetValue(key, out _);
+        }
+
+        public bool TryGetValue(string key, out object value)
+        {
+            return TryGetByName(key, typeof(object), out value);
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            foreach (var parameter in _functionMetadata.Parameters)
+            {
+                if (TryGetByName(parameter.Name, typeof(object), out object result))
+                {
+                    yield return new KeyValuePair<string, object>(parameter.Name, result);
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/SapNwRfc/Internal/Dynamic/DynamicRfcStructure.cs
+++ b/src/SapNwRfc/Internal/Dynamic/DynamicRfcStructure.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using SapNwRfc.Internal.Interop;
+
+namespace SapNwRfc.Internal.Dynamic
+{
+    internal sealed class DynamicRfcStructure : DynamicObject, IReadOnlyDictionary<string, object>
+    {
+        private readonly RfcInterop _interop;
+        private readonly IntPtr _structureHandle;
+        private readonly ISapTypeMetadata _typeMetadata;
+
+        internal DynamicRfcStructure(RfcInterop interop, IntPtr structureHandle, ISapTypeMetadata typeMetadata)
+        {
+            _interop = interop;
+            _structureHandle = structureHandle;
+            _typeMetadata = typeMetadata;
+        }
+
+        private bool TryGetByName(string name, Type returnType, out object result)
+        {
+            if (_typeMetadata.Fields.TryGetValue(name, out ISapFieldMetadata field))
+            {
+                if (DynamicRfc.TryGetRfcValue(_interop, _structureHandle, field.Name, field.Type, field.GetTypeMetadata, returnType, out result))
+                {
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        private bool TryGetByIndex(int index, Type returnType, out object result)
+        {
+            if (index >= 0 && index < _typeMetadata.Fields.Count)
+            {
+                ISapFieldMetadata field = _typeMetadata.Fields[index];
+
+                if (DynamicRfc.TryGetRfcValue(_interop, _structureHandle, field.Name, field.Type, field.GetTypeMetadata, returnType, out result))
+                {
+                    return true;
+                }
+            }
+
+            result = null;
+            return false;
+        }
+
+        public override IEnumerable<string> GetDynamicMemberNames()
+        {
+            return Keys;
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            return TryGetByName(binder.Name, binder.ReturnType, out result);
+        }
+
+        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+        {
+            if (indexes.Length != 1)
+                throw new ArgumentOutOfRangeException(nameof(indexes));
+
+            var index = indexes[0];
+
+            if (index is string name)
+                return TryGetByName(name, binder.ReturnType, out result);
+
+            if (index is int i)
+                return TryGetByIndex(i, binder.ReturnType, out result);
+
+            if (index is uint u)
+                return TryGetByIndex((int)u, binder.ReturnType, out result);
+
+            throw new ArgumentException(nameof(indexes));
+        }
+
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+        {
+            if (binder.Name == "GetMetadata" && binder.CallInfo.ArgumentCount == 0)
+            {
+                result = _typeMetadata;
+                return true;
+            }
+
+            return base.TryInvokeMember(binder, args, out result);
+        }
+
+        public IEnumerable<string> Keys
+        {
+            get
+            {
+                foreach (var field in _typeMetadata.Fields)
+                {
+                    yield return field.Name;
+                }
+            }
+        }
+
+        public IEnumerable<object> Values
+        {
+            get
+            {
+                foreach (var field in _typeMetadata.Fields)
+                {
+                    if (TryGetByName(field.Name, typeof(object), out object result))
+                    {
+                        yield return result;
+                    }
+                }
+            }
+        }
+
+        public int Count => _typeMetadata.Fields.Count;
+
+        public object this[string key]
+        {
+            get
+            {
+                if (TryGetByName(key, typeof(object), out var result))
+                {
+                    return result;
+                }
+
+                throw new KeyNotFoundException();
+            }
+        }
+
+        public bool ContainsKey(string key)
+        {
+            return _typeMetadata.Fields.TryGetValue(key, out _);
+        }
+
+        public bool TryGetValue(string key, out object value)
+        {
+            return TryGetByName(key, typeof(object), out value);
+        }
+
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+        {
+            foreach (var field in _typeMetadata.Fields)
+            {
+                if (TryGetByName(field.Name, typeof(object), out object result))
+                {
+                    yield return new KeyValuePair<string, object>(field.Name, result);
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/SapNwRfc/Internal/Dynamic/DynamicRfcTable.cs
+++ b/src/SapNwRfc/Internal/Dynamic/DynamicRfcTable.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Dynamic;
+using SapNwRfc.Internal.Interop;
+
+namespace SapNwRfc.Internal.Dynamic
+{
+    internal sealed class DynamicRfcTable : DynamicObject, IReadOnlyList<object>
+    {
+        private readonly RfcInterop _interop;
+        private readonly IntPtr _tableHandle;
+        private readonly ISapTypeMetadata _typeMetadata;
+        private uint? _rowCount;
+
+        public DynamicRfcTable(RfcInterop interop, IntPtr tableHandle, ISapTypeMetadata sapTypeMetadata)
+        {
+            _interop = interop;
+            _tableHandle = tableHandle;
+            _typeMetadata = sapTypeMetadata;
+        }
+
+        private uint GetRowCount()
+        {
+            if (!_rowCount.HasValue)
+            {
+                RfcResultCode resultCode = _interop.GetRowCount(
+                    tableHandle: _tableHandle,
+                    rowCount: out uint rowCount,
+                    errorInfo: out RfcErrorInfo errorInfo);
+
+                errorInfo.ThrowOnError();
+
+                _rowCount = rowCount;
+            }
+
+            return _rowCount.Value;
+        }
+
+        private bool TryGetValueByIndex(uint index, out object result)
+        {
+            RfcResultCode resultCode = _interop.MoveTo(
+                tableHandle: _tableHandle,
+                index: index,
+                errorInfo: out RfcErrorInfo errorInfo);
+
+            resultCode.ThrowOnError(errorInfo);
+
+            IntPtr rowHandle = _interop.GetCurrentRow(
+                tableHandle: _tableHandle,
+                errorInfo: out errorInfo);
+
+            errorInfo.ThrowOnError();
+
+            result = new DynamicRfcStructure(_interop, rowHandle, _typeMetadata);
+            return true;
+        }
+
+        public override IEnumerable<string> GetDynamicMemberNames()
+        {
+            yield return "Count";
+        }
+
+        public override bool TryGetMember(GetMemberBinder binder, out object result)
+        {
+            if (binder.Name == "Count")
+            {
+                result = GetRowCount();
+                return true;
+            }
+
+            return base.TryGetMember(binder, out result);
+        }
+
+        public override bool TryGetIndex(GetIndexBinder binder, object[] indexes, out object result)
+        {
+            if (indexes.Length != 1)
+                throw new ArgumentException(nameof(indexes));
+
+            var index = indexes[0];
+
+            if (index is int i)
+                return TryGetValueByIndex((uint)i, out result);
+
+            if (index is uint u)
+                return TryGetValueByIndex(u, out result);
+
+            throw new ArgumentException(nameof(indexes));
+        }
+
+        public override bool TryInvokeMember(InvokeMemberBinder binder, object[] args, out object result)
+        {
+            if (binder.Name == "GetMetadata" && binder.CallInfo.ArgumentCount == 0)
+            {
+                result = _typeMetadata;
+                return true;
+            }
+
+            return base.TryInvokeMember(binder, args, out result);
+        }
+
+        public int Count => (int)GetRowCount();
+
+        public object this[int index]
+        {
+            get
+            {
+                if (TryGetValueByIndex((uint)index, out object result))
+                {
+                    return result;
+                }
+
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+        }
+
+        public IEnumerator<object> GetEnumerator()
+        {
+            RfcResultCode moveFirstResultCode = _interop.MoveToFirstRow(
+                tableHandle: _tableHandle,
+                errorInfo: out RfcErrorInfo moveFirstErrorInfo);
+
+            if (moveFirstResultCode == RfcResultCode.RFC_TABLE_MOVE_BOF)
+                yield break;
+
+            moveFirstResultCode.ThrowOnError(moveFirstErrorInfo);
+
+            while (true)
+            {
+                IntPtr rowHandle = _interop.GetCurrentRow(
+                    tableHandle: _tableHandle,
+                    errorInfo: out RfcErrorInfo errorInfo);
+
+                errorInfo.ThrowOnError();
+
+                yield return new DynamicRfcStructure(_interop, rowHandle, _typeMetadata);
+
+                RfcResultCode moveNextResultCode = _interop.MoveToNextRow(
+                    tableHandle: _tableHandle,
+                    errorInfo: out RfcErrorInfo moveNextErrorInfo);
+
+                if (moveNextResultCode == RfcResultCode.RFC_TABLE_MOVE_EOF)
+                    yield break;
+
+                moveNextResultCode.ThrowOnError(moveNextErrorInfo);
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/SapNwRfc/Internal/Interop/RfcInterop.cs
+++ b/src/SapNwRfc/Internal/Interop/RfcInterop.cs
@@ -316,6 +316,12 @@ namespace SapNwRfc.Internal.Interop
             => RfcMoveToFirstRow(tableHandle, out errorInfo);
 
         [DllImport(SapNwRfcDllName)]
+        private static extern RfcResultCode RfcMoveTo(IntPtr tableHandle, uint index, out RfcErrorInfo errorInfo);
+
+        public virtual RfcResultCode MoveTo(IntPtr tableHandle, uint index, out RfcErrorInfo errorInfo)
+            => RfcMoveTo(tableHandle, index, out errorInfo);
+
+        [DllImport(SapNwRfcDllName)]
         private static extern IntPtr RfcAppendNewRow(IntPtr tableHandle, out RfcErrorInfo errorInfo);
 
         public virtual IntPtr AppendNewRow(IntPtr tableHandle, out RfcErrorInfo errorInfo)

--- a/src/SapNwRfc/SapFunction.cs
+++ b/src/SapNwRfc/SapFunction.cs
@@ -1,5 +1,6 @@
 using System;
 using SapNwRfc.Internal;
+using SapNwRfc.Internal.Dynamic;
 using SapNwRfc.Internal.Interop;
 
 namespace SapNwRfc
@@ -96,6 +97,11 @@ namespace SapNwRfc
         {
             Invoke();
 
+            if (typeof(TOutput) == typeof(object))
+            {
+                return (TOutput)(object)new DynamicRfcFunction(_interop, _functionHandle, Metadata);
+            }
+
             return OutputMapper.Extract<TOutput>(_interop, _functionHandle);
         }
 
@@ -103,6 +109,11 @@ namespace SapNwRfc
         public TOutput Invoke<TOutput>(object input)
         {
             Invoke(input);
+
+            if (typeof(TOutput) == typeof(object))
+            {
+                return (TOutput)(object)new DynamicRfcFunction(_interop, _functionHandle, Metadata);
+            }
 
             return OutputMapper.Extract<TOutput>(_interop, _functionHandle);
         }

--- a/src/SapNwRfc/SapServerFunction.cs
+++ b/src/SapNwRfc/SapServerFunction.cs
@@ -1,5 +1,6 @@
 using System;
 using SapNwRfc.Internal;
+using SapNwRfc.Internal.Dynamic;
 using SapNwRfc.Internal.Interop;
 
 namespace SapNwRfc
@@ -55,6 +56,11 @@ namespace SapNwRfc
         /// <inheritdoc cref="ISapServerFunction"/>
         public TOutput GetParameters<TOutput>()
         {
+            if (typeof(TOutput) == typeof(object))
+            {
+                return (TOutput)(object)new DynamicRfcFunction(_interop, _functionHandle, Metadata);
+            }
+
             return OutputMapper.Extract<TOutput>(_interop, _functionHandle);
         }
 

--- a/tests/SapNwRfc.Tests/Internal/Dynamic/DynamicRfcTests.cs
+++ b/tests/SapNwRfc.Tests/Internal/Dynamic/DynamicRfcTests.cs
@@ -1,0 +1,333 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using FluentAssertions;
+using Moq;
+using SapNwRfc.Internal.Dynamic;
+using SapNwRfc.Internal.Interop;
+using Xunit;
+
+namespace SapNwRfc.Tests.Internal.Dynamic
+{
+    public sealed class DynamicRfcTests
+    {
+        private static readonly IntPtr DataHandle = (IntPtr)123;
+        private readonly Mock<RfcInterop> _interopMock = new Mock<RfcInterop>();
+
+        private delegate void GetStringCallback(IntPtr dataHandle, string name, char[] buffer, uint bufferLength, out uint stringLength, out RfcErrorInfo errorInfo);
+
+        private delegate void GetDateCallback(IntPtr dataHandle, string name, char[] buffer, out RfcErrorInfo errorInfo);
+
+        private delegate void GetTimeCallback(IntPtr dataHandle, string name, char[] buffer, out RfcErrorInfo errorInfo);
+
+        private delegate void GetXStringCallback(IntPtr dataHandle, string name, byte[] buffer, uint bufferLength, out uint xstringLength, out RfcErrorInfo errorInfo);
+
+        [Theory]
+        [InlineData("", (int)SapRfcType.RFCTYPE_STRING)]
+        [InlineData("hello", (int)SapRfcType.RFCTYPE_STRING)]
+        [InlineData("hello", (int)SapRfcType.RFCTYPE_CHAR)]
+        [InlineData("hello", (int)SapRfcType.RFCTYPE_NUM)]
+        [InlineData("hello", (int)SapRfcType.RFCTYPE_BCD)]
+        public void TryGetRfcValue_String(string value, int type)
+        {
+            // Arrange
+            string stringValue = value;
+            uint stringLength = (uint)stringValue.Length;
+            RfcErrorInfo errorInfo;
+            var resultCodeQueue = new Queue<RfcResultCode>();
+            resultCodeQueue.Enqueue(RfcResultCode.RFC_BUFFER_TOO_SMALL);
+            resultCodeQueue.Enqueue(RfcResultCode.RFC_OK);
+            _interopMock
+                .Setup(x => x.GetString(It.IsAny<IntPtr>(), It.IsAny<string>(), It.IsAny<char[]>(), It.IsAny<uint>(), out stringLength, out errorInfo))
+                .Callback(new GetStringCallback((IntPtr dataHandle, string name, char[] buffer, uint bufferLength, out uint sl, out RfcErrorInfo ei) =>
+                {
+                    ei = default;
+                    sl = stringLength;
+                    if (buffer.Length <= 0 || bufferLength <= 0)
+                        return;
+                    Array.Copy(stringValue.ToCharArray(), buffer, stringValue.Length);
+                }))
+                .Returns(resultCodeQueue.Dequeue);
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", (SapRfcType)type, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(1, (int)SapRfcType.RFCTYPE_INT)]
+        [InlineData(2, (int)SapRfcType.RFCTYPE_INT1)]
+        [InlineData(3, (int)SapRfcType.RFCTYPE_INT2)]
+        public void TryGetRfcValue_Integer(int value, int type)
+        {
+            // Arrange
+            int intValue = value;
+            RfcErrorInfo errorInfo;
+            _interopMock.Setup(x => x.GetInt(It.IsAny<IntPtr>(), It.IsAny<string>(), out intValue, out errorInfo));
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", (SapRfcType)type, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(1, (int)SapRfcType.RFCTYPE_INT8)]
+        public void TryGetRfcValue_Long(long value, int type)
+        {
+            // Arrange
+            long longValue = value;
+            RfcErrorInfo errorInfo;
+            _interopMock.Setup(x => x.GetInt8(It.IsAny<IntPtr>(), It.IsAny<string>(), out longValue, out errorInfo));
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", (SapRfcType)type, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(1.5, (int)SapRfcType.RFCTYPE_FLOAT)]
+        public void TryGetRfcValue_Float(double value, int type)
+        {
+            // Arrange
+            double doubleValue = value;
+            RfcErrorInfo errorInfo;
+            _interopMock.Setup(x => x.GetFloat(It.IsAny<IntPtr>(), It.IsAny<string>(), out doubleValue, out errorInfo));
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", (SapRfcType)type, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData(1.1, (int)SapRfcType.RFCTYPE_DECF16)]
+        [InlineData(2.2, (int)SapRfcType.RFCTYPE_DECF34)]
+        public void TryGetRfcValue_Decimal(decimal value, int type)
+        {
+            // Arrange
+            string stringValue = value.ToString(CultureInfo.InvariantCulture);
+            uint stringLength = (uint)stringValue.Length;
+            RfcErrorInfo errorInfo;
+            var resultCodeQueue = new Queue<RfcResultCode>();
+            resultCodeQueue.Enqueue(RfcResultCode.RFC_BUFFER_TOO_SMALL);
+            resultCodeQueue.Enqueue(RfcResultCode.RFC_OK);
+            _interopMock
+                .Setup(x => x.GetString(It.IsAny<IntPtr>(), It.IsAny<string>(), It.IsAny<char[]>(), It.IsAny<uint>(), out stringLength, out errorInfo))
+                .Callback(new GetStringCallback((IntPtr dataHandle, string name, char[] buffer, uint bufferLength, out uint sl, out RfcErrorInfo ei) =>
+                {
+                    ei = default;
+                    sl = stringLength;
+                    if (buffer.Length <= 0 || bufferLength <= 0)
+                        return;
+                    Array.Copy(stringValue.ToCharArray(), buffer, stringValue.Length);
+                }))
+                .Returns(resultCodeQueue.Dequeue);
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", (SapRfcType)type, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(value);
+        }
+
+        [Theory]
+        [InlineData("20200405", (int)SapRfcType.RFCTYPE_DATE)]
+        public void TryGetRfcValue_Date(string value, int type)
+        {
+            // Arrange
+            string stringValue = value;
+            RfcErrorInfo errorInfo;
+            _interopMock
+                .Setup(x => x.GetDate(It.IsAny<IntPtr>(), It.IsAny<string>(), It.IsAny<char[]>(), out errorInfo))
+                .Callback(new GetDateCallback((IntPtr dataHandle, string name, char[] buffer, out RfcErrorInfo ei) =>
+                {
+                    ei = default;
+                    Array.Copy(stringValue.ToCharArray(), buffer, stringValue.Length);
+                }))
+                .Returns(RfcResultCode.RFC_OK);
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", (SapRfcType)type, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(new DateTime(2020, 04, 05));
+        }
+
+        [Theory]
+        [InlineData("123456", (int)SapRfcType.RFCTYPE_TIME)]
+        public void TryGetRfcValue_Time(string value, int type)
+        {
+            // Arrange
+            string stringValue = value;
+            RfcErrorInfo errorInfo;
+            _interopMock
+                .Setup(x => x.GetTime(It.IsAny<IntPtr>(), It.IsAny<string>(), It.IsAny<char[]>(), out errorInfo))
+                .Callback(new GetTimeCallback((IntPtr dataHandle, string name, char[] buffer, out RfcErrorInfo ei) =>
+                {
+                    ei = default;
+                    Array.Copy(stringValue.ToCharArray(), buffer, stringValue.Length);
+                }))
+                .Returns(RfcResultCode.RFC_OK);
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", (SapRfcType)type, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(new TimeSpan(12, 34, 56));
+        }
+
+        [Theory(Skip = "Needs dynamic buffer length detection.")]
+        [InlineData(new object[] { new byte[] { 1, 2, 3 }, (int)SapRfcType.RFCTYPE_BYTE })]
+        [InlineData(new object[] { new byte[] { 1, 2, 3 }, (int)SapRfcType.RFCTYPE_XSTRING })]
+        public void TryGetRfcValue_Byte(byte[] value, int type)
+        {
+            // Arrange
+            uint byteLength = (uint)value.Length;
+            RfcErrorInfo errorInfo;
+            _interopMock
+               .Setup(x => x.GetXString(It.IsAny<IntPtr>(), It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<uint>(), out byteLength, out errorInfo))
+               .Callback(new GetXStringCallback((IntPtr dataHandle, string name, byte[] buffer, uint bufferLength, out uint sl, out RfcErrorInfo ei) =>
+               {
+                   ei = default;
+                   sl = byteLength;
+                   Array.Copy(value, buffer, value.Length);
+               }))
+                .Returns(RfcResultCode.RFC_OK);
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", (SapRfcType)type, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(value);
+        }
+
+        [Fact]
+        public void TryGetRfcValue_Null()
+        {
+            // Arrange
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", SapRfcType.RFCTYPE_NULL, null, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public void TryGetRfcValue_Structure()
+        {
+            // Arrange
+            IntPtr structHandle;
+            RfcErrorInfo errorInfo;
+            _interopMock.Setup(x => x.GetStructure(It.IsAny<IntPtr>(), It.IsAny<string>(), out structHandle, out errorInfo));
+
+            int intValue = 10;
+            _interopMock.Setup(x => x.GetInt(It.IsAny<IntPtr>(), It.IsAny<string>(), out intValue, out errorInfo));
+
+            Mock<ISapFieldMetadata> fieldMetadatMock = new Mock<ISapFieldMetadata>();
+            fieldMetadatMock.SetupGet(x => x.Name).Returns("TEST");
+            fieldMetadatMock.SetupGet(x => x.Type).Returns(SapRfcType.RFCTYPE_INT);
+            ISapFieldMetadata fieldMetadata = fieldMetadatMock.Object;
+
+            Mock<ISapMetadataCollection<ISapFieldMetadata>> metadataCollectionMock = new Mock<ISapMetadataCollection<ISapFieldMetadata>>();
+            metadataCollectionMock.SetupGet(x => x.Count).Returns(1);
+            metadataCollectionMock.SetupGet(x => x[It.Is<int>(i => i == 0)]).Returns(fieldMetadata);
+            metadataCollectionMock.Setup(x => x.TryGetValue(It.Is<string>(n => n == "TEST"), out fieldMetadata)).Returns(true);
+            metadataCollectionMock.Setup(x => x.GetEnumerator()).Returns(new List<ISapFieldMetadata> { fieldMetadata }.GetEnumerator());
+
+            Mock<ISapTypeMetadata> metadataMock = new Mock<ISapTypeMetadata>();
+            metadataMock.SetupGet(x => x.Fields).Returns(metadataCollectionMock.Object);
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", SapRfcType.RFCTYPE_STRUCTURE, () => metadataMock.Object, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().BeAssignableTo<IReadOnlyDictionary<string, object>>();
+
+            dynamic dynamicStructure = result;
+
+            ((object)dynamicStructure.Count).Should().Be(1);
+            ((object)dynamicStructure.TEST).Should().Be(intValue);
+            ((object)dynamicStructure[0]).Should().Be(intValue);
+
+            foreach (dynamic kvp in dynamicStructure)
+            {
+                ((object)kvp.Key).Should().Be("TEST");
+                ((object)kvp.Value).Should().Be(intValue);
+            }
+        }
+
+        [Fact]
+        public void TryGetRfcValue_Table()
+        {
+            // Arrange
+            IntPtr tableHandle;
+            RfcErrorInfo errorInfo;
+            _interopMock.Setup(x => x.GetTable(It.IsAny<IntPtr>(), It.IsAny<string>(), out tableHandle, out errorInfo));
+
+            uint rowCount = 1;
+            _interopMock.Setup(x => x.GetRowCount(It.IsAny<IntPtr>(), out rowCount, out errorInfo));
+
+            _interopMock.Setup(x => x.MoveTo(It.IsAny<IntPtr>(), It.Is<uint>(i => i == 0), out errorInfo));
+            _interopMock.Setup(x => x.GetCurrentRow(It.IsAny<IntPtr>(), out errorInfo));
+
+            IntPtr structHandle;
+            _interopMock.Setup(x => x.GetStructure(It.IsAny<IntPtr>(), It.IsAny<string>(), out structHandle, out errorInfo));
+
+            int intValue = 10;
+            _interopMock.Setup(x => x.GetInt(It.IsAny<IntPtr>(), It.IsAny<string>(), out intValue, out errorInfo));
+
+            _interopMock.Setup(x => x.MoveToFirstRow(It.IsAny<IntPtr>(), out errorInfo));
+            var resultCodeQueue = new Queue<RfcResultCode>();
+            resultCodeQueue.Enqueue(RfcResultCode.RFC_OK);
+            resultCodeQueue.Enqueue(RfcResultCode.RFC_TABLE_MOVE_EOF);
+            _interopMock.Setup(x => x.MoveToNextRow(It.IsAny<IntPtr>(), out errorInfo)).Returns(resultCodeQueue.Dequeue);
+
+            Mock<ISapFieldMetadata> fieldMetadatMock = new Mock<ISapFieldMetadata>();
+            fieldMetadatMock.SetupGet(x => x.Name).Returns("TEST");
+            fieldMetadatMock.SetupGet(x => x.Type).Returns(SapRfcType.RFCTYPE_INT);
+            ISapFieldMetadata fieldMetadata = fieldMetadatMock.Object;
+
+            Mock<ISapMetadataCollection<ISapFieldMetadata>> metadataCollectionMock = new Mock<ISapMetadataCollection<ISapFieldMetadata>>();
+            metadataCollectionMock.SetupGet(x => x.Count).Returns(1);
+            metadataCollectionMock.Setup(x => x.TryGetValue(It.Is<string>(n => n == "TEST"), out fieldMetadata)).Returns(true);
+
+            Mock<ISapTypeMetadata> metadataMock = new Mock<ISapTypeMetadata>();
+            metadataMock.SetupGet(x => x.Fields).Returns(metadataCollectionMock.Object);
+
+            // Act
+            bool valid = DynamicRfc.TryGetRfcValue(_interopMock.Object, DataHandle, "test", SapRfcType.RFCTYPE_TABLE, () => metadataMock.Object, typeof(object), out object result);
+
+            // Assert
+            valid.Should().BeTrue();
+            result.Should().BeAssignableTo<IReadOnlyList<object>>();
+
+            dynamic dynamicTable = result;
+
+            ((object)dynamicTable.Count).Should().Be(rowCount);
+            ((object)dynamicTable[0].TEST).Should().Be(intValue);
+
+            foreach (dynamic row in dynamicTable)
+            {
+                ((object)row.TEST).Should().Be(intValue);
+            }
+        }
+    }
+}

--- a/tests/SapNwRfc.Tests/SapNwRfc.Tests.csproj
+++ b/tests/SapNwRfc.Tests/SapNwRfc.Tests.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net5</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <CodeAnalysisRuleSet>..\..\ca.ruleset</CodeAnalysisRuleSet>
     <SignAssembly>true</SignAssembly>
-	  <DelaySign>false</DelaySign>
+    <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\Signing.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
@@ -32,6 +32,10 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\SapNwRfc\SapNwRfc.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Adds support for invoking a function with a `dynamic` return type. Values are read on demand and can not be accessed once the function gets disposed. ~Which means that this feature in its current state is not supported by `SapPooledConnection`.~

See https://github.com/huysentruitw/SapNwRfc/issues/36#issuecomment-885692636 for more usage details.