### PR TITLE
Add EnumerableField<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,22 @@ class SomeFunctionResultItem
 }
 ```
 
+### Define models with an IEnumerable
+
+```csharp
+class SomeFunctionResult
+{
+    [SapName("RES_ITEMS")]
+    public IEnumerable<SomeFunctionResultItem> Items { get; set; }
+}
+
+class SomeFunctionResultItem
+{
+    [SapName("ITM_NAME")]
+    public string Name { get; set; }
+}
+```
+
 ### Exclude properties from mapping
 
 ```csharp
@@ -320,19 +336,20 @@ For each input and output model type, the library builds and caches a mapping fu
 
 SAP RFC parameter types don't have to be specified as they're converted by convention. Here's an overview of supported type mappings:
 
-| C# type     | SAP RFC type                        | Remarks
-|:----------  |:----------------------------        |:---
-| `int`       | RFCTYPE_INT                         | 4-byte integer
-| `long`      | RFCTYPE_INT8                        | 8-byte integer
-| `double`    | RFCTYPE_FLOAT                       | Floating point, double precision
-| `decimal`   | RFCTYPE_BCD                         |
-| `string`    | RFCTYPE_STRING / RFCTYPE_CHAR / ... | Gets a data field as string 
-| `byte[]`    | RFCTYPE_BYTE                        | Raw binary data, fixed length. Has to be used in conjunction with the `[SapBufferLength]`-attribute
-| `char[]`    | RFCTYPE_CHAR                        | Char data, fixed length. Has to be used in conjunction with the `[SapBufferLength]`-attribute
-| `DateTime?` | RFCTYPE_DATE                        | Only the day, month and year value is used
-| `TimeSpan?` | RFCTYPE_TIME                        | Only the hour, minute and second value is used
-| `T`         | RFCTYPE_STRUCTURE                   | Structures are constructed from nested objects (T) in the input or output model (see [example](#define-models-with-a-nested-structure))
-| `Array<T>`  | RFCTYPE_TABLE                       | Tables are constructed from arrays of nested objects (T) in the input or output model (see [example](#define-models-with-a-nested-table))
+| C# type           | SAP RFC type                        | Remarks
+|:---------------   |:----------------------------        |:---
+| `int`             | RFCTYPE_INT                         | 4-byte integer
+| `long`            | RFCTYPE_INT8                        | 8-byte integer
+| `double`          | RFCTYPE_FLOAT                       | Floating point, double precision
+| `decimal`         | RFCTYPE_BCD                         |
+| `string`          | RFCTYPE_STRING / RFCTYPE_CHAR / ... | Gets a data field as string 
+| `byte[]`          | RFCTYPE_BYTE                        | Raw binary data, fixed length. Has to be used in conjunction with the `[SapBufferLength]`-attribute
+| `char[]`          | RFCTYPE_CHAR                        | Char data, fixed length. Has to be used in conjunction with the `[SapBufferLength]`-attribute
+| `DateTime?`       | RFCTYPE_DATE                        | Only the day, month and year value is used
+| `TimeSpan?`       | RFCTYPE_TIME                        | Only the hour, minute and second value is used
+| `T`               | RFCTYPE_STRUCTURE                   | Structures are constructed from nested objects (T) in the input or output model (see [example](#define-models-with-a-nested-structure))
+| `Array<T>`        | RFCTYPE_TABLE                       | Tables are constructed from arrays of nested objects (T) in the input or output model (see [example](#define-models-with-a-nested-table))
+| `IEnumerable<T>`  | RFCTYPE_TABLE                       | Tables returned as IEnumerable<T>. Yields elements one-by-one for better memory management when handling large datasets
 
 ## Connection pooling
 

--- a/src/SapNwRfc/Internal/Fields/EnumerableField.cs
+++ b/src/SapNwRfc/Internal/Fields/EnumerableField.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using SapNwRfc.Internal.Interop;
+
+namespace SapNwRfc.Internal.Fields
+{
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global", Justification = "Reflection use")]
+    internal sealed class EnumerableField<TItem> : Field<IEnumerable<TItem>>
+    {
+        public EnumerableField(string name, IEnumerable<TItem> value)
+            : base(name, value)
+        {
+        }
+
+        public override void Apply(RfcInterop interop, IntPtr dataHandle)
+        {
+            if (Value == null)
+                return;
+
+            RfcResultCode resultCode = interop.GetTable(
+                dataHandle: dataHandle,
+                name: Name,
+                out IntPtr tableHandle,
+                out RfcErrorInfo errorInfo);
+
+            resultCode.ThrowOnError(errorInfo);
+
+            foreach (TItem row in Value)
+            {
+                IntPtr lineHandle = interop.AppendNewRow(tableHandle, out errorInfo);
+                errorInfo.ThrowOnError();
+                InputMapper.Apply(interop, lineHandle, row);
+            }
+        }
+
+        public static EnumerableField<T> Extract<T>(RfcInterop interop, IntPtr dataHandle, string name)
+        {
+            RfcResultCode resultCode = interop.GetTable(
+                dataHandle: dataHandle,
+                name: name,
+                tableHandle: out IntPtr tableHandle,
+                errorInfo: out RfcErrorInfo errorInfo);
+
+            resultCode.ThrowOnError(errorInfo);
+
+            resultCode = interop.GetRowCount(
+                tableHandle: tableHandle,
+                rowCount: out uint rowCount,
+                errorInfo: out errorInfo);
+
+            resultCode.ThrowOnError(errorInfo);
+
+            if (rowCount == 0)
+                return new EnumerableField<T>(name, Enumerable.Empty<T>());
+
+            IEnumerable<T> rows = YieldTableRows<T>(interop, tableHandle);
+
+            return new EnumerableField<T>(name, rows);
+        }
+
+        public static IEnumerable<T> YieldTableRows<T>(RfcInterop interop, IntPtr tableHandle)
+        {
+            RfcResultCode moveFirstResultCode = interop.MoveToFirstRow(
+                tableHandle: tableHandle,
+                errorInfo: out RfcErrorInfo moveFirstErrorInfo);
+
+            if (moveFirstResultCode == RfcResultCode.RFC_TABLE_MOVE_BOF)
+                yield break;
+
+            moveFirstResultCode.ThrowOnError(moveFirstErrorInfo);
+
+            while (true)
+            {
+                IntPtr rowHandle = interop.GetCurrentRow(
+                    tableHandle: tableHandle,
+                    errorInfo: out RfcErrorInfo errorInfo);
+
+                errorInfo.ThrowOnError();
+
+                yield return OutputMapper.Extract<T>(interop, rowHandle);
+
+                RfcResultCode moveNextResultCode = interop.MoveToNextRow(
+                    tableHandle: tableHandle,
+                    errorInfo: out RfcErrorInfo moveNextErrorInfo);
+
+                if (moveNextResultCode == RfcResultCode.RFC_TABLE_MOVE_EOF)
+                    yield break;
+
+                moveNextResultCode.ThrowOnError(moveNextErrorInfo);
+            }
+        }
+
+        [ExcludeFromCodeCoverage]
+        public override string ToString()
+            => string.Join(Environment.NewLine, Value.Select((row, index) => $"[{index}] {row}"));
+    }
+}

--- a/src/SapNwRfc/Internal/InputMapper.cs
+++ b/src/SapNwRfc/Internal/InputMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Linq.Expressions;
@@ -127,6 +128,13 @@ namespace SapNwRfc.Internal
             {
                 // new RfcTableField<TElementType>(name, (TElementType[])value);
                 Type tableFieldType = typeof(TableField<>).MakeGenericType(propertyInfo.PropertyType.GetElementType());
+                fieldConstructor = tableFieldType.GetConstructor(new[] { typeof(string), propertyInfo.PropertyType });
+            }
+            else if (propertyInfo.PropertyType.GetInterfaces().Contains(typeof(IEnumerable)))
+            {
+                Type elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
+
+                Type tableFieldType = typeof(EnumerableField<>).MakeGenericType(elementType);
                 fieldConstructor = tableFieldType.GetConstructor(new[] { typeof(string), propertyInfo.PropertyType });
             }
             else if (!propertyInfo.PropertyType.IsPrimitive)

--- a/src/SapNwRfc/Internal/OutputMapper.cs
+++ b/src/SapNwRfc/Internal/OutputMapper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -120,7 +121,16 @@ namespace SapNwRfc.Internal
             else if (propertyInfo.PropertyType.IsArray)
             {
                 Type elementType = propertyInfo.PropertyType.GetElementType();
+
                 extractMethod = GetMethodInfo(() => TableField<object>.Extract<object>(default, default, default))
+                    .GetGenericMethodDefinition()
+                    .MakeGenericMethod(elementType);
+            }
+            else if (propertyInfo.PropertyType.GetInterfaces().Contains(typeof(IEnumerable)))
+            {
+                Type elementType = propertyInfo.PropertyType.GetGenericArguments()[0];
+
+                extractMethod = GetMethodInfo(() => EnumerableField<object>.Extract<object>(default, default, default))
                     .GetGenericMethodDefinition()
                     .MakeGenericMethod(elementType);
             }


### PR DESCRIPTION
This enables using `IEnumerable<T>` on input and output models. On input models there is no difference to using arrays.

On output models the rows will be returned one-by-one using `yield return`. Rows are loaded from SAP individually with each iteration on the enumerable. This enables very large datasets to be handled without everything to be loaded into memory all at once.

In conjunction with `InvokeFunction` of pooling, the generated function now has to be stored and not disposed immediately. Otherwise the `tableHandle` would be destroyed on SAP side and calling any interop method using this handle will throw `RFC_INVALID_HANDLE`.

