### PR TITLE
Keep reference to generic server function delegates so they don't get GCed and crash the application

### DIFF
--- a/src/SapNwRfc/Internal/Interop/RfcInterop.cs
+++ b/src/SapNwRfc/Internal/Interop/RfcInterop.cs
@@ -329,7 +329,7 @@ namespace SapNwRfc.Internal.Interop
         public delegate RfcResultCode RfcServerFunction(IntPtr connectionHandle, IntPtr functionHandle, out RfcErrorInfo errorInfo);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall, CharSet = CharSet.Unicode)]
-        public delegate RfcResultCode RfcFunctionDescriptionCallback(string functionName, RfcAttributes attributes, ref IntPtr funcDescHandle);
+        public delegate RfcResultCode RfcFunctionDescriptionCallback(string functionName, RfcAttributes attributes, out IntPtr funcDescHandle);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         public delegate void RfcServerErrorListener(IntPtr serverHandle, in RfcAttributes clientInfo, in RfcErrorInfo errorInfo);


### PR DESCRIPTION
Extracted the fix from https://github.com/huysentruitw/SapNwRfc/pull/53

Fixes https://github.com/huysentruitw/SapNwRfc/issues/56