### PR TITLE
Adjust `ToInterop` to consider custom parameters in subclasses

### DIFF
--- a/src/SapNwRfc/Internal/Interop/Extensions/SapConnectionParametersExtensions.cs
+++ b/src/SapNwRfc/Internal/Interop/Extensions/SapConnectionParametersExtensions.cs
@@ -14,8 +14,9 @@ namespace SapNwRfc.Internal.Interop
         public static RfcConnectionParameter[] ToInterop<TParameters>(this TParameters parameters)
             where TParameters : SapConnectionParameters
         {
+            // Use .GetType() here to support custom parameters in subclasses of <TParameters>
             (string Name, Func<object, string> GetValue)[] properties =
-                TypePropertiesCache.GetOrAdd(typeof(TParameters), Build);
+                TypePropertiesCache.GetOrAdd(parameters.GetType(), Build);
 
             return properties
                 .Select(property =>


### PR DESCRIPTION
Relates to #82, but does not fix all of it.

This change makes using subclasses of `SapConnectionParameters` possible when creating a connection.  
It does NOT fix `SapConnectionParameters.Parse()` since that requires a slightly different fix.