### PR TITLE
Clear RFC table rows before applying values

### DIFF
--- a/src/SapNwRfc/Internal/Fields/EnumerableField.cs
+++ b/src/SapNwRfc/Internal/Fields/EnumerableField.cs
@@ -27,6 +27,9 @@ namespace SapNwRfc.Internal.Fields
 
             resultCode.ThrowOnError(errorInfo);
 
+            // Clear the table content before adding more - these tables are re-used between calls
+            interop.DeleteAllRows(tableHandle, out errorInfo);
+
             foreach (TItem row in Value)
             {
                 IntPtr lineHandle = interop.AppendNewRow(tableHandle, out errorInfo);

--- a/src/SapNwRfc/Internal/Fields/TableField.cs
+++ b/src/SapNwRfc/Internal/Fields/TableField.cs
@@ -26,6 +26,11 @@ namespace SapNwRfc.Internal.Fields
 
             resultCode.ThrowOnError(errorInfo);
 
+            // Clear the table content before adding more - these tables are re-used between calls
+            interop.DeleteAllRows(tableHandle, out errorInfo);
+
+            resultCode.ThrowOnError(errorInfo);
+
             foreach (TItem row in Value)
             {
                 IntPtr lineHandle = interop.AppendNewRow(tableHandle, out errorInfo);

--- a/src/SapNwRfc/Internal/Interop/RfcInterop.cs
+++ b/src/SapNwRfc/Internal/Interop/RfcInterop.cs
@@ -321,6 +321,12 @@ namespace SapNwRfc.Internal.Interop
         public virtual IntPtr AppendNewRow(IntPtr tableHandle, out RfcErrorInfo errorInfo)
             => RfcAppendNewRow(tableHandle, out errorInfo);
 
+        [DllImport(SapNwRfcDllName)]
+        private static extern RfcResultCode RfcDeleteAllRows(IntPtr tableHandle, out RfcErrorInfo errorInfo);
+
+        public virtual RfcResultCode DeleteAllRows(IntPtr tableHandle, out RfcErrorInfo errorInfo)
+            => RfcDeleteAllRows(tableHandle, out errorInfo);
+
         #endregion
 
         #region Server

--- a/tests/SapNwRfc.Tests/Internal/InputMapperTests.cs
+++ b/tests/SapNwRfc.Tests/Internal/InputMapperTests.cs
@@ -307,6 +307,7 @@ namespace SapNwRfc.Tests.Internal
             InputMapper.Apply(_interopMock.Object, DataHandle, model);
 
             // Assert
+            _interopMock.Verify(x => x.DeleteAllRows(tableHandle, out errorInfo));
             _interopMock.Verify(x => x.AppendNewRow(tableHandle, out errorInfo), Times.Exactly(numberOfRows));
             foreach (ArrayElement element in model.SomeArray)
             {
@@ -363,6 +364,7 @@ namespace SapNwRfc.Tests.Internal
             InputMapper.Apply(_interopMock.Object, DataHandle, model);
 
             // Assert
+            _interopMock.Verify(x => x.DeleteAllRows(tableHandle, out errorInfo));
             _interopMock.Verify(x => x.AppendNewRow(tableHandle, out errorInfo), Times.Exactly(numberOfRows));
             foreach (EnumerableElement element in model.SomeEnumerable)
             {


### PR DESCRIPTION
As tables may be re-used between calls of the same SapFunction, there may still be rows left over from previous calls. Before applying parameter data to tables, clear the content of the table to avoid duplicate data.